### PR TITLE
Adding in pull approve config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,2 +1,8 @@
 version: 3
-extends: "https://api.github.com/repos/medology/Scripts/contents/Pull%20Approve/base.pullapprove.yml?ref=master"
+extends: "https://api.github.com/repos/medology/Scripts/contents/config/base.pullapprove.yml?ref=master"
+groups:
+  min_global_approvals:
+    reviewers:
+      teams:
+        - Back-end
+


### PR DESCRIPTION
Adding in config extending the scripts repos base config. This configuration has been simplified to fix several issues we are having with pull aprove 


Note for QA: Pull requests are solely updating the config file for how we assign reviewers. Nothing in this PR will be testable.